### PR TITLE
fix: remove imports to `zx/globals`

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,7 +1,5 @@
 #!/usr/bin/env zx
 
-import 'zx/globals';
-
 const osPaths = {
   darwin: `${os.homedir()}/Library/Application Support/discord/settings.json`,
   win32: `${os.homedir()}/AppData/discord/settings.json`,


### PR DESCRIPTION
Remove imports to `zx/globals` so it doesn't throw exceptions:

```
node:internal/errors:464
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zx' imported from /tmp/index.mjs
    at new NodeError (node:internal/errors:371:5)
    at packageResolve (node:internal/modules/esm/resolve:884:9)
    at moduleResolve (node:internal/modules/esm/resolve:929:18)
    at defaultResolve (node:internal/modules/esm/resolve:1044:11)
    at ESMLoader.resolve (node:internal/modules/esm/loader:422:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:222:40)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:40)
    at link (node:internal/modules/esm/module_job:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

```