### PR TITLE
chore: update instructions on how to run the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,23 +48,16 @@ It's ready now just restart discord
 
 ## Using zx (Method 2)
 
-Clone project
+Install zx
 
 ```sh
-git clone git@github.com:BrunoS3D/discord-enable-devtools.git
-cd discord-enable-devtools
+npm i -g zx
 ```
 
-Install deps
+Run the script
 
 ```sh
-npm i
-```
-
-Run script
-
-```sh
-npm run start
+zx https://raw.githubusercontent.com/BrunoS3D/discord-enable-devtools/main/index.mjs
 ```
 
 It's ready now just restart discord


### PR DESCRIPTION
This PR adds instructions on how to run the script using HTTP, without the need to clone the repo and install dependencies.

These instructions will only work after #2 is merged